### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 AutoDocs MCP Server automatically provides AI assistants with contextual, version-specific documentation for Python project dependencies, eliminating manual package lookup and providing more accurate coding assistance.
 
+<a href="https://glama.ai/mcp/servers/@bradleyfay/autodoc-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bradleyfay/autodoc-mcp/badge" alt="AutoDocs Server MCP server" />
+</a>
+
 ## Features
 
 - **Automatic Dependency Scanning**: Parse pyproject.toml files and extract dependency information


### PR DESCRIPTION
This PR adds a badge for the [AutoDocs MCP Server](https://glama.ai/mcp/servers/@bradleyfay/autodoc-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@bradleyfay/autodoc-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@bradleyfay/autodoc-mcp/badge" alt="AutoDocs Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.